### PR TITLE
Update visible

### DIFF
--- a/js/pageguide.js
+++ b/js/pageguide.js
@@ -518,7 +518,7 @@ tl.pg.interval = {};
      **/
     tl.pg.PageGuide.prototype.updateVisible = function () {
         this.refreshVisibleSteps();
-        if (this.cur_selector != null && this.cur_selector !== this.visibleTargets[this.cur_idx]) {
+        if (this.cur_selector == null || this.cur_selector !== this.visibleTargets[this.cur_idx]) {
             // mod by target length in case user was viewing last target and it got removed
             var newIndex = this.cur_idx % this.visibleTargets.length;
             this.show_message(newIndex);

--- a/js/pageguide.js
+++ b/js/pageguide.js
@@ -518,7 +518,16 @@ tl.pg.interval = {};
      **/
     tl.pg.PageGuide.prototype.updateVisible = function () {
         this.refreshVisibleSteps();
-        if (this.cur_selector == null || this.cur_selector !== this.visibleTargets[this.cur_idx]) {
+        if (this.visibleTargets.length == 0)
+        {
+            if (this.$message.is(":visible"))
+            {
+                this.$message.animate({ height: "0" }, 500, function() {
+                  $(this).hide();
+                });
+            }
+        }
+        else if (this.cur_selector == null || this.cur_selector !== this.visibleTargets[this.cur_idx]) {
             // mod by target length in case user was viewing last target and it got removed
             var newIndex = this.cur_idx % this.visibleTargets.length;
             this.show_message(newIndex);


### PR DESCRIPTION
If there are no visible elements when _open() is called, subsequent calls to updateVisible() will create steps as they appear, but the $messages div will never appear, and no step will be marked current. Additionally, if all elements become non-visible, the step markers will disappear, but the messages div remains.

This patch alters the updateVisible() call so that if there are no steps visible, the messages div is animated away. Otherwise, if no currentStep is assigned or if the current step has changed (using the previous logic) then the show_message method is called.