### PR TITLE
docs: Fix simple typo, incrimenting -> incrementing

### DIFF
--- a/js/tests/benchmark/benchmark.js
+++ b/js/tests/benchmark/benchmark.js
@@ -536,7 +536,7 @@
    *
    * In Opera < 9.50 and some older/beta Mobile Safari versions using `unshift()`
    * generically to augment the `arguments` object will pave the value at index 0
-   * without incrimenting the other values's indexes.
+   * without incrementing the other values's indexes.
    * https://github.com/documentcloud/underscore/issues/9
    *
    * Rhino and environments it powers, like Narwhal and RingoJS, may have


### PR DESCRIPTION
There is a small typo in js/tests/benchmark/benchmark.js.

Should read `incrementing` rather than `incrimenting`.

